### PR TITLE
Fix introduce text retrieval in main screen

### DIFF
--- a/business_card/lib/main_screen.dart
+++ b/business_card/lib/main_screen.dart
@@ -210,7 +210,7 @@ class _MainScreenState extends State<MainScreen> {
 
   Future<void> getIntroduceData() async {
     final sharedPref = await SharedPreferences.getInstance();
-    String introduceMsg = sharedPref.getString('introduce').toString();
+    String? introduceMsg = sharedPref.getString('introduce');
     introduceController.text = introduceMsg ?? "";
   }
 }


### PR DESCRIPTION
## Summary
- handle missing SharedPreferences value for introduce text

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840615355748326878373cadea992c3