### PR TITLE
Fix introduce message default

### DIFF
--- a/business_card/lib/main_screen.dart
+++ b/business_card/lib/main_screen.dart
@@ -210,7 +210,7 @@ class _MainScreenState extends State<MainScreen> {
 
   Future<void> getIntroduceData() async {
     final sharedPref = await SharedPreferences.getInstance();
-    String introduceMsg = sharedPref.getString('introduce').toString();
-    introduceController.text = introduceMsg ?? "";
+    final introduceMsg = sharedPref.getString('introduce') ?? '';
+    introduceController.text = introduceMsg;
   }
 }


### PR DESCRIPTION
## Summary
- store introduce text as empty string when not set

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840620a4e14832699ef736646e6cb6c